### PR TITLE
Change from COPYRIGHT to LICENSE.txt

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,9 +1,0 @@
-Copyright (c) 1994-2015 John Bradley Plevyak, All Rights Reserved
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-   3. The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 1994-2020, John Bradley Plevyak
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Makefile
+++ b/Makefile
@@ -90,14 +90,14 @@ endif
 
 CFLAGS += -pedantic
 
-AUX_FILES = dparser/Makefile dparser/COPYRIGHT dparser/README.md dparser/CHANGES dparser/4calc.g dparser/4calc.in dparser/my.g dparser/my.c dparser/index.html dparser/manual.html dparser/faq.html dparser/make_dparser.1 dparser/make_dparser.cat
+AUX_FILES = dparser/Makefile dparser/LICENSE.txt dparser/README.md dparser/CHANGES dparser/4calc.g dparser/4calc.in dparser/my.g dparser/my.c dparser/index.html dparser/manual.html dparser/faq.html dparser/make_dparser.1 dparser/make_dparser.cat
 TESTS = $(shell ls tests/*g tests/*[0-9] tests/*.check tests/*.flags)
 TEST_FILES = dparser/parser_tests dparser/baseline $(TESTS:%=dparser/%)
 PYTHON_FILES = dparser/python/Makefile dparser/python/*.py dparser/python/*.c dparser/python/*.h dparser/python/*.i dparser/python/README dparser/python/*.html dparser/python/contrib/d* dparser/python/tests/*.py
 VERILOG_FILES = dparser/verilog/Makefile dparser/verilog/verilog.g dparser/verilog/README dparser/verilog/ambig.c \
 dparser/verilog/main.c dparser/verilog/vparse.c dparser/verilog/vparse.h dparser/verilog/verilog_tests
 TAR_FILES = $(AUX_FILES) $(TEST_FILES) $(PYTHON_FILES) $(VERILOG_FILES) dparser/D_BUILD_VERSION \
-dparser/grammar.g dparser/sample.g dparser/my.g 
+dparser/grammar.g dparser/sample.g dparser/my.g
 
 LIB_SRCS = arg.c parse.c scan.c symtab.c util.c read_binary.c dparse_tree.c
 LIB_OBJS = $(LIB_SRCS:%.c=%.o)
@@ -168,7 +168,7 @@ deinstall:
 	rm $(MANPAGES:%=$(PREFIX)/man/man1/%)
 
 make_dparser: $(MAKE_PARSER_OBJS) $(LIBRARIES)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ version.c $(LIBS) 
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ version.c $(LIBS)
 
 $(LIBDPARSE): $(LIB_OBJS)
 	ar crv $@ $^
@@ -207,7 +207,7 @@ D_BUILD_VERSION:
 	mv D_BUILD_VERSION.tmp D_BUILD_VERSION
 
 tar:
-	(cd ..;tar czf dparser-$(RELEASE)-src.tar.gz dparser/*.c dparser/*.h $(TAR_FILES)) 
+	(cd ..;tar czf dparser-$(RELEASE)-src.tar.gz dparser/*.c dparser/*.h $(TAR_FILES))
 
 bintar:
 	(cd ..;tar czf d-$(RELEASE)-$(OS_TYPE)-bin.tar.gz $(AUX_FILES) $(LIBRARIES:%=dparser/%) $(INCLUDES:%=dparser/%) $(EXECUTABLE_FILES:%=dparser/%))

--- a/make_dparser.1
+++ b/make_dparser.1
@@ -21,8 +21,8 @@ in a given state. This provides an easy way to build
 grammars for languages which use longest match lexical
 ambiguity resolution (e.g. ANSI-C, C++). (OFF by default)
 .IP "\-T"
-Toggle building of a tokenizer for START.  When ON, instead of generating 
-a unique scanner for each state (i.e. a 'scannerless' parser), 
+Toggle building of a tokenizer for START.  When ON, instead of generating
+a unique scanner for each state (i.e. a 'scannerless' parser),
 generate a single scanner (tokenizer) for the entire grammar.  This provides
 an easy way to build grammars for languages which assume a
 tokenizer (e.g. ANSI C). (OFF by default)
@@ -32,7 +32,7 @@ Write header, 0 : no, 1 : yes, \-1 : only if not empty.
 Token type, 0 : #define, 1 : enum.
 .IP "\-C"
 Toggle computing whitespace states.  If 'whitespace' is
-defined in the grammar, then use it as a subparser to 
+defined in the grammar, then use it as a subparser to
 consume whitespace. (ON by default)
 .IP "\-A"
 Toggle computing states for all non-terminals.  Ensures that there is a unique
@@ -48,11 +48,11 @@ for most grammars. (defaults to 4)
 files.
 .IP "\-p"
 Toggle setting of operator priority from rules.  Setting of operator
-priorities on operator tokens can increase the size of the tables but 
+priorities on operator tokens can increase the size of the tables but
 can permit unnecessary parse stacks to be pruned earlier. (OFF by default)
 .IP "\-r"
 Toggle use of right recursion for EBNF productions.  Do not change this
-unless you really know what you are doing. (OFF by default) 
+unless you really know what you are doing. (OFF by default)
 .IP "\-L"
 Toggle writing of line numbers.  Used to debug the parsing table
 generator itself. (ON by default)
@@ -96,12 +96,12 @@ D_MAKE_PARSER_DEBUG.
 The features are covered in the documentation.  See the README file.
 .SH FILES
 .PP
-None.	
+None.
 .SH NO WARRANTIES
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-COPYRIGHT for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+LICENSE.txt for more details.
 .SH SEE ALSO
 .PP
 .BR flex (1),

--- a/make_dparser.cat
+++ b/make_dparser.cat
@@ -95,8 +95,8 @@ FILES
 NO WARRANTIES
        This program is distributed in the hope that it  will  be  useful,  but
        WITHOUT  ANY  WARRANTY;  without  even  the  implied  warranty  of MER-
-       CHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See  the  COPYRIGHT
-       for more details.
+       CHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See LICENSE.txt  for
+       more details.
 
 SEE ALSO
        flex(1), yacc(1), bison(1)


### PR DESCRIPTION
Used the github template for a BSD 3-Clause License. It is more up to date and (I hope) it reflects the original COPYRIGHT and the intentions of the author.

This changes how Github display the project's license to a nicer, more informative way. Instead of it showing a balance and saying `View license`, it will now show the balance and say `BSD-3-Clause License.

**NOTE**: the project blurb has a typo, it says `generater` but the correct spelling is `generator`.

![Screenshot from 2020-07-23 17-28-18](https://user-images.githubusercontent.com/208546/88331028-a04edf00-cd2c-11ea-9801-c993c029e943.png)
