### PR TITLE
More changes to make includes scope smaller

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -4,13 +4,21 @@
 #include "d.h"
 #include "arg.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef __alpha
+#define atoll atol
+#endif
+
 static char *SPACES = "                                                                               ";
 static char *arg_types_keys = (char *)"ISDfF+TL";
 static char *arg_types_desc[] = {(char *)"int     ", (char *)"string  ", (char *)"double  ",
                                  (char *)"set off ", (char *)"set on  ", (char *)"incr    ",
                                  (char *)"toggle  ", (char *)"int64   ", (char *)"        "};
 
-void process_arg(ArgumentState *arg_state, int i, char ***argv) {
+static void process_arg(ArgumentState *arg_state, int i, char ***argv) {
   char *arg = NULL;
   ArgumentDescription *desc = arg_state->desc;
   if (desc[i].type) {

--- a/arg.h
+++ b/arg.h
@@ -4,14 +4,6 @@
 #ifndef _arg_H_
 #define _arg_H_
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#ifndef __alpha
-#define atoll atol
-#endif
-
 /* Argument Handling
  */
 struct ArgumentState;

--- a/d.h
+++ b/d.h
@@ -4,36 +4,24 @@
 #ifndef _d_H_
 #define _d_H_
 
+#if !defined(__FreeBSD__) || (__FreeBSD_version >= 500000)
+#include <stdint.h>
+#include <inttypes.h>
+#endif
+
+#if 0
+/*
+ * FIXME
+ * I believe this uses https://www.linkdata.se/sourcecode/memwatch/ which
+ * doesn't seem to have been updated since 2003?
+ */
 #define __USE_MINGW_ANSI_STDIO 1
 #ifdef MEMWATCH
 #define MEMWATCH_STDIO 1
 #include "../../src/memwatch-2.67/memwatch.h"
 #define MEM_GROW_MACRO
 #endif
-#include <assert.h>
-#include <stdarg.h>
-#include <stdlib.h>
-#include <stdio.h>
-#if !defined(__FreeBSD__) || (__FreeBSD_version >= 500000)
-#include <inttypes.h>
 #endif
-#include <limits.h>
-#include <sys/types.h>
-#if !defined(__MINGW32__) && !defined(WIN32)
-#include <sys/mman.h>
-#include <sys/uio.h>
-#endif
-#if !defined(WIN32)
-#include <unistd.h>
-#include <sys/time.h>
-#include <dirent.h>
-#endif
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <time.h>
-#include <ctype.h>
-#include <string.h>
-#include <strings.h>
 
 #ifdef LEAK_DETECT
 #define GC_DEBUG

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -116,9 +116,9 @@ code with braces `{` `}`.
 
 Example:
 ```Yacc
-{ void dr_s() { printf("Dr. S\n"); } }
+{ void dr_s(void) { printf("Dr. S\n"); } }
 S: 'the' 'cat' 'and' 'the' 'hat' { dr_s(); } | T;
-{ void twain() { printf("Mark Twain\n"); }
+{ void twain(void) { printf("Mark Twain\n"); }
 T: 'Huck' 'Finn' { twain(); };
 ```
 

--- a/dparse.h
+++ b/dparse.h
@@ -4,6 +4,13 @@
 #ifndef _dparse_H_
 #define _dparse_H_
 
+/*
+ * FIXME
+ * This file has a bunch of prototypes for functions.
+ * Many of them are defined in parse.c -- why aren't these prototypes in
+ * parse.h then???
+ */
+
 #include <stdlib.h>
 #if defined(__cplusplus)
 extern "C" {
@@ -78,7 +85,8 @@ void d_pass(D_Parser *p, D_ParseNode *pn, int pass_number);
 
 int resolve_amb_greedy(D_Parser *dp, int n, D_ParseNode **v);
 
-char *d_dup_pathname_str(const char *str);
+D_ParseNode *ambiguity_count_fn(D_Parser *pp, int n, D_ParseNode **v);
+D_ParseNode *ambiguity_abort_fn(D_Parser *pp, int n, D_ParseNode **v);
 
 #if defined(__cplusplus)
 }

--- a/dparse_tree.c
+++ b/dparse_tree.c
@@ -6,11 +6,11 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "d.h"
+#include "util.h"
 #include "dparse_tables.h"
 #include "dparse.h"
 #include "dparse_tree.h"
-
-char *dup_str(char *s, char *e); /* defined in util.h */
 
 /* tunables */
 

--- a/dsymtab.c
+++ b/dsymtab.c
@@ -2,6 +2,10 @@
   Copyright 2002-2004 John Plevyak, All Rights Reserved
 */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "d.h"
 #include "util.h"
 #include "dsymtab.h"
@@ -74,7 +78,7 @@ static void symhash_add(D_SymHash *sh, D_Sym *s) {
   }
 }
 
-static D_SymHash *new_D_SymHash() {
+static D_SymHash *new_D_SymHash(void) {
   D_SymHash *sh = MALLOC(sizeof(D_SymHash));
   memset(sh, 0, sizeof(D_SymHash));
   sh->grow = INITIAL_SYMHASH_SIZE * 2 + 1;

--- a/dsymtab.h
+++ b/dsymtab.h
@@ -54,6 +54,8 @@ D_Scope *equiv_D_Scope(D_Scope *scope);
 D_Scope *global_D_Scope(D_Scope *scope);
 D_Scope *scope_D_Scope(D_Scope *current, D_Scope *scope);
 void free_D_Scope(D_Scope *st, int force);
+void print_scope(D_Scope *st);
+
 D_Sym *new_D_Sym(D_Scope *st, char *name, char *end, int sizeof_D_Sym);
 #define NEW_D_SYM(_st, _name, _end) new_D_Sym(_st, _name, _end, sizeof(D_Sym))
 D_Sym *find_D_Sym(D_Scope *st, char *name, char *end);
@@ -67,6 +69,6 @@ D_Sym *update_additional_D_Sym(D_Scope *st, D_Sym *sym, int sizeof_D_Sym);
 D_Sym *current_D_Sym(D_Scope *st, D_Sym *sym);
 D_Sym *find_D_Sym_in_Scope(D_Scope *st, D_Scope *cur, char *name, char *end);
 D_Sym *next_D_Sym_in_Scope(D_Scope **st, D_Sym **sym);
-void print_scope(D_Scope *st);
+void print_sym(D_Sym *s);
 
 #endif

--- a/gram.h
+++ b/gram.h
@@ -251,9 +251,6 @@ void print_rule(Rule *r);
 void print_term(Term *t);
 Production *lookup_production(Grammar *g, char *name, uint len);
 
-/* for creating grammars */
-#define last_elem(_r) ((_r)->elems.v[(_r)->elems.n - 1])
-
 Rule *new_rule(Grammar *g, Production *p);
 Elem *new_elem_nterm(Production *p, Rule *r);
 void new_declaration(Grammar *g, Elem *e, uint kind);
@@ -268,15 +265,13 @@ Production *new_internal_production(Grammar *g, Production *p);
 Elem *dup_elem(Elem *e, Rule *r);
 void add_declaration(Grammar *g, char *start, char *end, uint kind, uint line);
 void add_pass(Grammar *g, char *start, char *end, uint kind, uint line);
-void add_pass_code(Grammar *g, Rule *r, char *pass_start, char *pass_end, char *code_start, char *code_end, uint line,
-                   uint pass_line);
+void add_pass_code(Grammar *g, Rule *r, char *pass_start, char *pass_end, char *code_start, char *code_end, uint line, uint pass_line);
 D_Pass *find_pass(Grammar *g, char *start, char *end);
 void conditional_EBNF(Grammar *g); /* applied to g->e,g->r,g->p */
 void star_EBNF(Grammar *g);        /* ditto */
 void plus_EBNF(Grammar *g);        /* ditto */
 void rep_EBNF(Grammar *g, int minimum, int maximum);
 void initialize_productions(Grammar *g);
-void finalize_productions(Grammar *g);
 uint state_for_declaration(Grammar *g, uint iproduction);
 
 #endif

--- a/lex.c
+++ b/lex.c
@@ -2,6 +2,12 @@
   Copyright 2002-2004 John Plevyak, All Rights Reserved
 */
 
+#include <ctype.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "d.h"
 #include "util.h"
 #include "dparse_tables.h"
@@ -42,7 +48,7 @@ static NFAState *new_NFAState(LexState *ls) {
   return n;
 }
 
-static DFAState *new_DFAState() {
+static DFAState *new_DFAState(void) {
   DFAState *n = MALLOC(sizeof(DFAState));
   memset(n, 0, sizeof(DFAState));
   return n;
@@ -73,7 +79,7 @@ static void free_VecNFAState(VecNFAState *nfas) {
   vec_free(nfas);
 }
 
-static ScanState *new_ScanState() {
+static ScanState *new_ScanState(void) {
   ScanState *n = MALLOC(sizeof(ScanState));
   memset(n, 0, sizeof(ScanState));
   return n;
@@ -486,7 +492,7 @@ static void build_state_scanner(Grammar *g, LexState *ls, State *s) {
   ls->scanners++;
 }
 
-static LexState *new_LexState() {
+static LexState *new_LexState(void) {
   LexState *ls = MALLOC(sizeof(LexState));
   memset(ls, 0, sizeof(LexState));
   vec_clear(&ls->allnfas);

--- a/lr.c
+++ b/lr.c
@@ -2,13 +2,14 @@
   Copyright 2002-2004 John Plevyak, All Rights Reserved
 */
 
+#include <stdlib.h>
+#include <string.h>
+
 #include "d.h"
 #include "util.h"
 #include "dparse_tables.h"
 #include "gram.h"
 #include "lr.h"
-
-#define INITIAL_ALLITEMS 3359
 
 #define item_hash(_i) \
   (((uint)(_i)->rule->index << 8) + ((uint)((_i)->kind != ELEM_END ? (_i)->index : (_i)->rule->elems.n)))
@@ -28,7 +29,7 @@ static int itemcmp(const void *ai, const void *aj) {
   return (i > j) ? 1 : ((i < j) ? -1 : 0);
 }
 
-static State *new_state() {
+static State *new_state(void) {
   State *s = MALLOC(sizeof(State));
   memset(s, 0, sizeof(State));
   return s;
@@ -229,7 +230,9 @@ static int actioncmp(const void *aa, const void *bb) {
   return ((i > j) ? 1 : ((i < j) ? -1 : 0));
 }
 
-void sort_VecAction(VecAction *v) { qsort(v->v, v->n, sizeof(Action *), actioncmp); }
+void sort_VecAction(VecAction *v) {
+    qsort(v->v, v->n, sizeof(Action *), actioncmp);
+}
 
 static void build_actions(Grammar *g) {
   uint x, y, z;

--- a/make_dparser.c
+++ b/make_dparser.c
@@ -1,6 +1,9 @@
 /*
   Copyright 2002-2004 John Plevyak, All Rights Reserved
 */
+#include <stdio.h>
+#include <string.h>
+
 #include "d.h"
 #include "util.h"
 #include "dparse_tables.h"

--- a/mkdparse.c
+++ b/mkdparse.c
@@ -15,6 +15,10 @@ static void mkdparse_internal(Grammar *g, char *grammar_pathname, char *str) {
   if (build_grammar(g) < 0) d_fail("unable to load grammar '%s'", grammar_pathname);
 }
 
-void mkdparse(Grammar *g, char *grammar_pathname) { mkdparse_internal(g, grammar_pathname, 0); }
+void mkdparse(Grammar *g, char *grammar_pathname) {
+    mkdparse_internal(g, grammar_pathname, 0);
+}
 
-void mkdparse_from_string(Grammar *g, char *str) { mkdparse_internal(g, 0, str); }
+void mkdparse_from_string(Grammar *g, char *str) {
+    mkdparse_internal(g, 0, str);
+}

--- a/parse.h
+++ b/parse.h
@@ -4,10 +4,6 @@
 #ifndef _parse_H_
 #define _parse_H_
 
-#define NO_DPN ((D_ParseNode *)0x1)
-#define DPN_TO_PN(_dpn) ((PNode *)(((char *)dpn) - (intptr_t)(&((PNode *)0)->parse_node)))
-#define is_epsilon_PNode(_pn) ((_pn)->parse_node.start_loc.s == (_pn)->parse_node.end)
-
 /* #define TRACK_PNODES 1 */
 
 struct PNode;
@@ -146,7 +142,5 @@ typedef struct ZNode {
   VecSNode sns;
 } ZNode;
 #define znode_next(_z) (*(ZNode **)&((_z)->pn))
-
-D_ParseNode *ambiguity_count_fn(D_Parser *pp, int n, D_ParseNode **v);
 
 #endif

--- a/python/pydparser.c
+++ b/python/pydparser.c
@@ -9,7 +9,7 @@
 static int my_final_action(void *new_ps, void **children, int n_children, int pn_offset,
 			   struct D_Parser *parser);
 static int my_speculative_action(void *new_ps, void **children, int n_children, int pn_offset,
-				 struct D_Parser *parser); 
+				 struct D_Parser *parser);
 static PyObject *make_pyobject_from_node(D_Parser *parser, D_ParseNode *d, int string);
 
 typedef struct D_ParserPyInterface {
@@ -28,14 +28,14 @@ typedef struct D_ParserPyInterface {
   int takes_globals;
   char *buf_start;         /* for converting from char* to string index */
   PyObject *py_buf_start;
-  /* for deallocation purposes */ 
-  int num_parse_tree_viewers;    
-  D_ParseNode *top_node; 
+  /* for deallocation purposes */
+  int num_parse_tree_viewers;
+  D_ParseNode *top_node;
   int parsing;
 
 } D_ParserPyInterface;
 
-static void 
+static void
 free_node_fn(D_ParseNode *d) {
   Py_XDECREF((PyObject*)d->user.t);
   Py_XDECREF((PyObject*)d->user.s);
@@ -52,7 +52,7 @@ free_node_fn(D_ParseNode *d) {
 }
 
 /* swig can't handle these I don't think.*/
-void 
+void
 my_d_loc_t_s_set(d_loc_t *dlt, D_Parser *dp, int val) {
   D_ParserPyInterface *ppi = d_interface(dp);
   dlt->s = val + ppi->buf_start;
@@ -64,25 +64,25 @@ my_d_loc_t_s_get(d_loc_t *dlt, D_Parser *dp) {
   return dlt->s - ppi->buf_start;
 }
 
-void 
+void
 my_D_ParseNode_end_set(D_ParseNode *dpn, D_Parser *dp, int val) {
   D_ParserPyInterface *ppi = d_interface(dp);
   dpn->end = val + ppi->buf_start;
 }
 
-void 
+void
 my_D_ParseNode_end_skip_set(D_ParseNode *dpn, D_Parser *dp, int val) {
   D_ParserPyInterface *ppi = d_interface(dp);
   dpn->end_skip = val + ppi->buf_start;
 }
 
-int 
+int
 my_D_ParseNode_end_get(D_ParseNode *dpn, D_Parser *dp) {
   D_ParserPyInterface *ppi = d_interface(dp);
   return dpn->end - ppi->buf_start;
 }
 
-int 
+int
 my_D_ParseNode_end_skip_get(D_ParseNode *dpn, D_Parser *dp) {
   D_ParserPyInterface *ppi = d_interface(dp);
   return dpn->end_skip - ppi->buf_start;
@@ -105,7 +105,7 @@ my_D_ParseNode_symbol_get(D_ParseNode *dpn, D_Parser *dp) {
   return str;
 }
 
-static PyObject * 
+static PyObject *
 new_loc_inst(D_Parser* dp, d_loc_t* dlt) {
   PyObject * buf;
   D_ParserPyInterface *ppi = d_interface(dp);
@@ -139,7 +139,7 @@ make_py_node(D_Parser *dp, D_ParseNode *dpn) {
   return node_inst;
 }
 
-void 
+void
 remove_parse_tree_viewer(D_Parser* dp) {
   D_ParserPyInterface *ppi = d_interface(dp);
   ppi->num_parse_tree_viewers--;
@@ -157,7 +157,7 @@ add_parse_tree_viewer(D_Parser* dp) {
   ppi->num_parse_tree_viewers++;
 }
 
-static void 
+static void
 my_syntax_error_fn(struct D_Parser *dp) {
   PyObject *arglist;
   PyObject *result;
@@ -173,8 +173,8 @@ my_syntax_error_fn(struct D_Parser *dp) {
   Py_DECREF(loc_inst);
 }
 
-static void 
-my_initial_white_space_fn(struct D_Parser *dp, 
+static void
+my_initial_white_space_fn(struct D_Parser *dp,
 			 d_loc_t *loc, void **p_globals) {
   PyObject *arglist;
   PyObject *result;
@@ -244,7 +244,7 @@ make_parser(long int idpt,
 	    PyObject *syntax_error_fn,
 	    PyObject *ambiguity_fn,
 	    int dont_fixup_internal_productions,
-            int fixup_EBNF_productions, 
+            int fixup_EBNF_productions,
 	    int dont_merge_epsilon_trees,
 	    int commit_actions_interval,
 	    int error_recovery,
@@ -261,7 +261,7 @@ make_parser(long int idpt,
   D_Parser *p = new_D_Parser(dpt->parser_tables_gram, sizeof(D_ParseNode_User));
   p->fixup_EBNF_productions = fixup_EBNF_productions;
   p->save_parse_tree = 1;
-  p->initial_scope = NULL; 
+  p->initial_scope = NULL;
   p->dont_fixup_internal_productions = dont_fixup_internal_productions;
   p->dont_merge_epsilon_trees = dont_merge_epsilon_trees;
   p->commit_actions_interval = commit_actions_interval;
@@ -271,7 +271,7 @@ make_parser(long int idpt,
   p->dont_use_height_for_disambiguation = dont_use_height_for_disambiguation;
   p->error_recovery = error_recovery;
   p->free_node_fn = free_node_fn;
-  ppi = malloc(sizeof(D_ParserPyInterface)); 
+  ppi = malloc(sizeof(D_ParserPyInterface));
   memset(ppi, 0, sizeof(D_ParserPyInterface));
   ((Parser*)p)->pinterface1 = ppi;
   /* d_interface(p) = ppi; */
@@ -322,7 +322,7 @@ make_parser(long int idpt,
   return p;
 }
 
-void 
+void
 del_parser(D_Parser *dp) {
   D_ParserPyInterface *ppi;
   ppi = d_interface(dp);
@@ -496,8 +496,8 @@ print_debug_info(D_ParseNode *dd, PyObject *tuple, int speculative, int pdi) {
 }
 
 static PyObject*
-take_action(PyObject *arg_types, PyObject *children_list, int speculative, 
-	    D_ParseNode *dd, PyObject *string_list, int n_children, 
+take_action(PyObject *arg_types, PyObject *children_list, int speculative,
+	    D_ParseNode *dd, PyObject *string_list, int n_children,
 	    struct D_Parser *parser, void **children, int pn_offset,
 	    PyObject *action) {
   int i;
@@ -581,7 +581,7 @@ my_action(void *new_ps, void **children, int n_children, int pn_offset,
     tuple = PyList_GetItem(ppi->actions, action_index);
     PyArg_ParseTuple(tuple, "OOi", &action, &arg_types, &takes_speculative);
   }
-  
+
   if (ppi->takes_globals) {
     inc_global_state(parser, dd);
   }
@@ -610,11 +610,11 @@ my_action(void *new_ps, void **children, int n_children, int pn_offset,
 	  printf("freeing2:%d\n", dd->user.s);*/
     Py_XDECREF(dd->user.s);
     dd->user.t = Py_None;
-    //    printf("dd1:%d\n", dd);
+    /* printf("dd1:%d\n", dd); */
     dd->user.s = NULL;
     Py_XDECREF(string_list);
     /*    printf("setting:%d\n", string_list);*/
-    //dd->user.s = string_list;
+    /* dd->user.s = string_list; */
 
     return 0;
   }
@@ -630,7 +630,7 @@ my_action(void *new_ps, void **children, int n_children, int pn_offset,
   /* this function owns children_list */
 
   if (action_index != -1) {
-    result = take_action(arg_types, children_list, speculative, dd, string_list, 
+    result = take_action(arg_types, children_list, speculative, dd, string_list,
 			 n_children, parser, children, pn_offset, action);
     Py_DECREF(children_list);
   } else {
@@ -653,20 +653,20 @@ my_action(void *new_ps, void **children, int n_children, int pn_offset,
   Py_XDECREF(dd->user.s);
   /*  if(dd->user.s)
       printf("setting2:%d\n", string_list);*/
-  //  printf("dd2:%d\n", dd);
+  /* printf("dd2:%d\n", dd); */
   dd->user.t = result;
-  dd->user.s = string_list;  
+  dd->user.s = string_list;
 
   return 0;
 }
 
-static int 
+static int
 my_final_action(void *new_ps, void **children, int n_children, int pn_offset,
 		struct D_Parser *parser) {
   return my_action(new_ps, children, n_children, pn_offset, parser, 0);
 }
 
-static int 
+static int
 my_speculative_action(void *new_ps, void **children, int n_children, int pn_offset,
 		      struct D_Parser *parser) {
   return my_action(new_ps, children, n_children, pn_offset, parser, 1);
@@ -677,7 +677,7 @@ d_version(char *v) {
   v[0] = 0;
 }
 
-long int 
+long int
 load_parser_tables(char *tables_name) {
   return (long int)read_binary_tables(tables_name, my_speculative_action, my_final_action);
 }

--- a/read_binary.c
+++ b/read_binary.c
@@ -2,6 +2,10 @@
   Copyright 2002-2008 John Plevyak, All Rights Reserved
 */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "d.h"
 #include "util.h"
 #include "dparse_tables.h"
@@ -16,8 +20,7 @@ static void read_chk(void *ptr, size_t size, size_t nmemb, FILE *fp, unsigned ch
   }
 }
 
-BinaryTables *read_binary_tables_internal(FILE *fp, unsigned char *str, D_ReductionCode spec_code,
-                                          D_ReductionCode final_code) {
+static BinaryTables *read_binary_tables_internal(FILE *fp, unsigned char *str, D_ReductionCode spec_code, D_ReductionCode final_code) {
   BinaryTablesHead tables;
   int i;
   BinaryTables *binary_tables = MALLOC(sizeof(BinaryTables));
@@ -75,8 +78,7 @@ BinaryTables *read_binary_tables_from_file(FILE *fp, D_ReductionCode spec_code, 
   return read_binary_tables_internal(fp, 0, spec_code, final_code);
 }
 
-BinaryTables *read_binary_tables_from_string(unsigned char *str, D_ReductionCode spec_code,
-                                             D_ReductionCode final_code) {
+BinaryTables *read_binary_tables_from_string(unsigned char *str, D_ReductionCode spec_code, D_ReductionCode final_code) {
   return read_binary_tables_internal(0, str, spec_code, final_code);
 }
 

--- a/sample.g
+++ b/sample.g
@@ -3,6 +3,9 @@
 */
 
 {
+#include <stdio.h>
+#include <string.h>
+
 #include "d.h"
 #include "util.h"
 #include "dsymtab.h"

--- a/sample_parser.c
+++ b/sample_parser.c
@@ -1,6 +1,8 @@
 /*
   Copyright 2002-2004 John Plevyak, All Rights Reserved
 */
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "d.h"
 #include "util.h"

--- a/scan.c
+++ b/scan.c
@@ -2,6 +2,8 @@
   Copyright 2002-2004 John Plevyak, All Rights Reserved
 */
 
+#include <string.h>
+
 #include "d.h"
 #include "dparse_tables.h"
 #include "scan.h"

--- a/test_parser.c
+++ b/test_parser.c
@@ -1,6 +1,8 @@
 /*
   Copyright 2002-2006 John Plevyak, All Rights Reserved
 */
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "d.h"
 #include "util.h"

--- a/util.c
+++ b/util.c
@@ -2,6 +2,22 @@
   Copyright 2002-2006 John Plevyak, All Rights Reserved
 */
 
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * FIXME
+ * I am not sure if anything else is necessary to make this work in Windows; I
+ * suspect it didn't already due to the use of open().
+ */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+
 #include "d.h"
 #include "util.h"
 

--- a/util.h
+++ b/util.h
@@ -6,15 +6,11 @@
 #define _util_H_
 
 #define INITIAL_SET_SIZE_INDEX 2
-
-#define INITIAL_VEC_SHIFT 3
-#define INITIAL_VEC_SIZE (1 << INITIAL_VEC_SHIFT)
-#define INITIAL_VEC_SIZE (1 << INITIAL_VEC_SHIFT)
-#define INTEGRAL_VEC_SIZE 3
-#define INTEGRAL_STACK_SIZE 8
-#define TRICK_VEC_SIZE (INITIAL_VEC_SIZE - INTEGRAL_VEC_ELEMENTS)
-
-#define SET_MAX_SEQUENTIAL 5
+#define INITIAL_VEC_SHIFT      3
+#define INITIAL_VEC_SIZE      (1 << INITIAL_VEC_SHIFT)
+#define INTEGRAL_VEC_SIZE      3
+#define INTEGRAL_STACK_SIZE    8
+#define SET_MAX_SEQUENTIAL     5
 
 #define IS_BIT_SET(_v, _s) ((_v)[(_s) / 8] & 1 << ((_s) % 8))
 #define SET_BIT(_v, _s) (_v)[(_s) / 8] |= (1 << ((_s) % 8))
@@ -46,17 +42,6 @@ typedef struct AbstractStack {
     _x *cur;                         \
     _x initial[INTEGRAL_STACK_SIZE]; \
   }
-
-#define vec_move(_a, _b)                                 \
-  do {                                                   \
-    (_a)->n = (_b)->n;                                   \
-    if ((_b)->v == (_b)->e) {                            \
-      memcpy(&(_a)->e[0], &(_b)->e[0], sizeof((_a)->e)); \
-      (_a)->v = (_a)->e;                                 \
-    } else                                               \
-      (_a)->v = (_b)->v;                                 \
-    vec_clear(_b);                                       \
-  } while (0)
 
 struct hash_fns_t;
 typedef uint32 (*hash_fn_t)(void *, struct hash_fns_t *);
@@ -114,7 +99,6 @@ void set_to_vec(void *av);
   } while (0)
 #define stack_head(_s) ((_s)->cur[-1])
 #define is_stack_empty(_s) ((_s)->cur == (_s)->start)
-#define stack_empty(_s) ((_s)->cur = (_s)->start)
 #define stack_depth(_s) ((_s)->cur - (_s)->start)
 #define stack_pop(_s) (*--((_s)->cur))
 #define stack_push(_s, _x)                                                   \
@@ -130,14 +114,9 @@ void *stack_push_internal(AbstractStack *, void *);
 int buf_read(const char *pathname, char **buf, int *len);
 char *sbuf_read(const char *pathname);
 
-#if defined(WIN32)
-#define STREQ(_x, _n, _s) ((_n == sizeof(_s) - 1) && !strnicmp(_x, _s, sizeof(_s) - 1))
-#else
-#define STREQ(_x, _n, _s) ((_n == sizeof(_s) - 1) && !strncasecmp(_x, _s, sizeof(_s) - 1))
-#endif
-
 void d_fail(const char *str, ...);
 void d_warn(const char *str, ...);
+char *d_dup_pathname_str(const char *str);
 char *dup_str(const char *str, const char *end);
 uint strhashl(const char *s, int len);
 void d_free(void *);

--- a/version.c
+++ b/version.c
@@ -1,6 +1,9 @@
 /*
  Copyright 2002-2004 John Plevyak, All Rights Reserved
 */
+#include <stdio.h>
+#include <string.h>
+
 #include "d.h"
 
 const char *git_commit_id = "$Id$";


### PR DESCRIPTION
* Get rid of a large list of includes in file d.h, and add only the needed H files in each C file.
* Remove unused functions and defines.
* Move #defines that are used by a single C file, into the C file.
* Make functions static if they are only used internally in a C file.
* Add some missing prototypes including missing `(void)` decls.
* Move some prototypes to a more appropriate H file.
* Add some FIXME comments &rightarrow; **PLEASE CHECK**