### PR TITLE
Be a crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ sample_parser
 /.vs
 /.install
 .aider*
+/Cargo.lock
+/target
+/.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
+[package]
+name = "dparser"
+version = "0.1.0"
+edition = "2024"
+
 [workspace]
 members = ["rust/dparser_lib", "rust/example"]
 resolver = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["rust/dparser_lib", "rust/example"]
+resolver = "3"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,3 +1,0 @@
-[workspace]
-members = ["dparser_lib", "example"]
-resolver = "3"


### PR DESCRIPTION
Changes necessary to use this as a dependency of another Rust crate.

It seems to me that the project structure ought to be reorganized somehow, but until then, perhaps this makes sense.