### PR TITLE
python: Add .gitignore / bare pyproject.toml

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,10 @@
+# Python-generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+# Virtual environments
+.venv

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython"]
+build-backend = "setuptools.build_meta"
+


### PR DESCRIPTION
`.gitignore` to exclude the usual Python output stuff
`pyproject.toml` Needed for setuptools to know to use cython in its build system

Out of scope for this PR: Moving `setup.py` fully into `pyproject.toml` (i.e. going full declarative: https://setuptools.pypa.io/en/latest/userguide/ext_modules.html )