### PR TITLE
Port Python tests to pytest and document binding behaviors

### DIFF
--- a/python/LICENSE.txt
+++ b/python/LICENSE.txt
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 1994-2026, John Bradley Plevyak
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,21 @@ build-backend = "setuptools.build_meta"
 name = "dparser"
 version = "1.31"
 description = "DParser for Python"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
+license = {text = "BSD-3-Clause"}
+classifiers = [
+    "License :: OSI Approved :: BSD Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: C",
+    "Topic :: Software Development :: Compilers",
+    "Topic :: Text Processing :: General",
+    "Intended Audience :: Developers",
+    "Operating System :: POSIX",
+]
 
 [project.urls]
 Homepage = "https://github.com/jplevyak/dparser"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dparser"
-version = "1.31"
+version = "1.37"
 description = "DParser for Python"
 requires-python = ">=3.10"
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE.txt"]
 classifiers = [
-    "License :: OSI Approved :: BSD Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,3 +25,8 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/jplevyak/dparser"
 
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]
+

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from dparser import Parser
+
+
+@pytest.fixture
+def make_parser(tmp_path):
+    def _factory(module, **kwargs):
+        return Parser(modules=module, parser_folder=str(tmp_path), **kwargs)
+    return _factory

--- a/python/tests/dparser_binding_behavior.md
+++ b/python/tests/dparser_binding_behavior.md
@@ -142,3 +142,30 @@ except dparser.SyntaxErr:
 
 `SyntaxErr` is still raised after the callback returns — the callback is for
 observation only, not suppression.
+
+---
+
+## Exceptions raised from `syntax_error_fn` are swallowed (unraisable)
+
+Unlike `ambiguity_fn` (which wraps the user callback in an explicit
+`try/except Exception` and falls back to `v[0]`), `syntax_error_fn`'s wrapper
+`my_syntax_error_fn` in `dparser.pyx` is declared `cdef void … noexcept with
+gil` and has no try/except.  Cython's `noexcept` contract means any Python
+exception raised from inside is routed through `sys.unraisablehook` — by
+default printing `Exception ignored in: 'dparser.my_syntax_error_fn'` to
+stderr — and the C caller continues as if the callback had returned
+normally.  The exception does **not** surface as the exception raised by
+`parse()`; `SyntaxErr` still raises from the native parse failure.
+
+```python
+def cb(loc):
+    raise RuntimeError('boom')   # never propagates to the parse() caller
+
+try:
+    parser.parse('5+x', syntax_error_fn=cb, error_recovery=True)
+except dparser.SyntaxErr:
+    pass    # this is the exception that surfaces; RuntimeError is lost
+```
+
+Use list-capture or flag-setting patterns to signal from these callbacks,
+not raised exceptions.

--- a/python/tests/dparser_binding_behavior.md
+++ b/python/tests/dparser_binding_behavior.md
@@ -1,0 +1,144 @@
+# dparser Python Binding — Interesting Findings
+
+Notes from writing the pytest suite. These are non-obvious behaviors that
+aren't documented elsewhere.
+
+---
+
+## `partial_parses=1` silently ignores trailing content
+
+`partial_parses=1` stops after the first complete parse and leaves the rest of
+the buffer unconsumed — no error, no skip function required.
+
+```python
+parser.parse('10+3junk', partial_parses=1).getStructure()  # 13, not an error
+```
+
+This is distinct from needing `initial_skip_space_fn` to handle trailing
+content: `partial_parses` doesn't attempt to consume the remainder at all.
+
+---
+
+## `buf_offset` skips arbitrary bytes, not just whitespace
+
+`buf_offset=N` tells the parser to start reading from byte N of the buffer.
+The skipped prefix doesn't need to be whitespace or otherwise valid grammar
+input.
+
+```python
+parser.parse('xx10+3', buf_offset=2).getStructure()  # 13
+```
+
+The combined test in `test_basic_arithmetic.py` uses `initial_skip_space_fn`
+alongside `buf_offset`, which obscures this: the skip function is only needed
+to handle `hello` sequences **between tokens**, not to justify the prefix.
+
+---
+
+## `ambiguity_fn` receives `DParseNode` objects, not action return values
+
+When two grammar rules match the same input, dparser calls `ambiguity_fn` with
+a list of `DParseNode` alternatives. The function must return one of those
+exact node objects (identity check, not equality) to select the parse to keep.
+
+Action return values (`user.t`) are **not yet populated** at call time — they
+are `None` for all nodes. Disambiguation must be done by choosing among the
+node objects themselves.
+
+```python
+def pick_first(v):
+    return v[0]   # v is a list of DParseNode; return one of them by identity
+
+parser.parse('a', ambiguity_fn=pick_first).getStructure()
+```
+
+Selecting different nodes produces different final `getStructure()` values,
+because the chosen node determines which subtree's actions run:
+
+```python
+results = {
+    parser.parse('a', ambiguity_fn=lambda v: v[0]).getStructure(),
+    parser.parse('a', ambiguity_fn=lambda v: v[-1]).getStructure(),
+}
+assert results == {1, 2}   # the two alternatives really do differ
+```
+
+---
+
+## `dparser.AmbiguityException` does not propagate from `ambiguity_fn`
+
+`dparser.my_ambiguity_func` is documented as raising `AmbiguityException` to
+signal unresolved ambiguity. In practice it is swallowed: the Cython callback
+(`my_ambiguity_fn` in `dparser.pyx`) wraps the call in `try/except Exception`
+and falls back to returning `v[0]` on any exception.
+
+```python
+# This does NOT raise — the exception is caught inside the Cython callback
+parser.parse('a', ambiguity_fn=dparser.my_ambiguity_func).getStructure()  # returns a value
+```
+
+To raise on ambiguity, raise from outside the callback:
+
+```python
+result = [None]
+
+def detecting_fn(v):
+    result[0] = 'ambiguous'
+    return v[0]
+
+parser.parse('a', ambiguity_fn=detecting_fn)
+if result[0] == 'ambiguous':
+    raise RuntimeError('ambiguous parse')
+```
+
+---
+
+## Without `ambiguity_fn`, an ambiguous grammar loops indefinitely
+
+If `ambiguity_fn` is not provided and the grammar is ambiguous for the given
+input, the C parser loops at the native level. There is no timeout and no
+Python exception — the process simply hangs.
+
+Always supply an `ambiguity_fn` when parsing with a grammar that can produce
+ambiguous parses.
+
+---
+
+## `dparser.SyntaxErr` is the exception for invalid input
+
+Parse failure raises `dparser.SyntaxErr` (not `SyntaxError`). It is not a
+subclass of `dparser.ParsingException` — the two exception classes are
+independent. Empty and incomplete input both raise it too.
+
+```python
+with pytest.raises(dparser.SyntaxErr):
+    parser.parse('not valid input for this grammar')
+```
+
+---
+
+## `syntax_error_fn` is only called when `error_recovery=True`
+
+Without `error_recovery=True`, the C parser exits immediately on failure
+without invoking the callback at all. Passing `syntax_error_fn` alone does
+nothing observable.
+
+```python
+# callback is never called without error_recovery=True
+parser.parse('5+x', syntax_error_fn=lambda loc: ...)  # callback silently ignored
+```
+
+With `error_recovery=True`, the callback fires with a `DLoc` that has `s`,
+`line`, `col`, and `buf` attributes pointing to the error position:
+
+```python
+locs = []
+try:
+    parser.parse('5+x', syntax_error_fn=locs.append, error_recovery=True)
+except dparser.SyntaxErr:
+    pass
+# locs[0].s == 2, locs[0].col == 2, locs[0].buf == b'5+x'
+```
+
+`SyntaxErr` is still raised after the callback returns — the callback is for
+observation only, not suppression.

--- a/python/tests/test_ambiguity.py
+++ b/python/tests/test_ambiguity.py
@@ -1,0 +1,66 @@
+"""Tests for ambiguity resolution via ambiguity_fn.
+
+When a grammar has two rules that match the same input, dparser calls
+ambiguity_fn with a list of DParseNode alternatives and uses whichever node
+the function returns to continue the parse.  User values (action return values)
+are not yet populated at call time, so disambiguation must be done by selecting
+among the node objects themselves.
+"""
+
+import types
+import pytest
+import dparser
+
+
+# Grammar where h1 and h2 both match 'a', creating an unresolved ambiguity
+# unless ambiguity_fn is provided.
+
+def _d_h(t):
+    'h : h1 | h2'
+    return t[0]
+
+
+def _d_h1(t):
+    "h1 : 'a'"
+    return 1
+
+
+def _d_h2(t):
+    "h2 : 'a'"
+    return 2
+
+
+@pytest.fixture
+def parser_ambig(make_parser):
+    mod = types.ModuleType('_ambig_grammar')
+    for attr, fn in [('d_h', _d_h), ('d_h1', _d_h1), ('d_h2', _d_h2)]:
+        setattr(mod, attr, fn)
+    return make_parser(mod)
+
+
+def test_ambiguity_fn_receives_both_alternatives(parser_ambig):
+    seen = []
+    def capture(v):
+        seen.extend(v)
+        return v[0]
+    parser_ambig.parse('a', ambiguity_fn=capture)
+    assert len(seen) == 2
+
+
+def test_ambiguity_fn_nodes_are_distinct_objects(parser_ambig):
+    nodes = []
+    def capture(v):
+        nodes.extend(v)
+        return v[0]
+    parser_ambig.parse('a', ambiguity_fn=capture)
+    assert nodes[0] is not nodes[1]
+
+
+def test_ambiguity_fn_selection_affects_result(parser_ambig):
+    # The two alternatives produce different final values; choosing different
+    # nodes should yield different getStructure() results.
+    results = {
+        parser_ambig.parse('a', ambiguity_fn=lambda v: v[0]).getStructure(),
+        parser_ambig.parse('a', ambiguity_fn=lambda v: v[-1]).getStructure(),
+    }
+    assert results == {1, 2}

--- a/python/tests/test_basic_arithmetic.py
+++ b/python/tests/test_basic_arithmetic.py
@@ -2,7 +2,6 @@
 
 import sys
 import pytest
-from dparser import Parser
 
 
 def d_S(t):
@@ -22,11 +21,8 @@ def _skip_hello(loc):
 
 
 @pytest.fixture
-def parser(tmp_path):
-    return Parser(
-        modules=sys.modules[__name__],
-        parser_folder=str(tmp_path),
-    )
+def parser(make_parser):
+    return make_parser(sys.modules[__name__])
 
 
 def test_addition(parser):

--- a/python/tests/test_basic_arithmetic.py
+++ b/python/tests/test_basic_arithmetic.py
@@ -34,7 +34,19 @@ def test_addition_with_skip_space(parser):
     assert result.getStructure() == 92
 
 
+def test_buf_offset_skips_prefix_bytes(parser):
+    # buf_offset skips arbitrary bytes, not just whitespace
+    assert parser.parse('xx10+3', buf_offset=2).getStructure() == 13
+
+
+def test_partial_parses_stops_at_first_complete_parse(parser):
+    # trailing content that the grammar can't consume is silently ignored
+    assert parser.parse('10+3junk', partial_parses=1).getStructure() == 13
+
+
 def test_partial_parse_with_offset_and_skip(parser):
+    # combined: buf_offset skips prefix, initial_skip_space_fn treats 'hello'
+    # as inter-token whitespace, partial_parses=1 tolerates the trailing 'hi'
     result = parser.parse(
         'hi10hello+3hellohi',
         buf_offset=2,

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -8,6 +8,8 @@ Key findings:
   after the callback returns — the callback is for observing/logging, not suppressing.
 - The DLoc passed to the callback has s/line/col/buf attributes pinpointing the
   error position in the input buffer.
+- Exceptions raised from syntax_error_fn do not propagate: Cython's noexcept
+  declaration routes them through sys.unraisablehook instead.
 """
 
 import sys
@@ -81,3 +83,22 @@ def test_syntax_error_fn_loc_points_to_error_position(parser):
     assert loc.s == 2       # 'x' is at index 2
     assert loc.line == 1
     assert loc.col == 2
+
+
+def test_syntax_error_fn_exception_does_not_propagate(parser):
+    # my_syntax_error_fn is declared `noexcept` in dparser.pyx, so any exception
+    # raised from the callback is reported via sys.unraisablehook instead of
+    # propagating.  SyntaxErr still raises from the native parse failure.
+    unraised = []
+    original_hook = sys.unraisablehook
+    sys.unraisablehook = unraised.append
+    try:
+        def cb(loc):
+            raise RuntimeError('should not propagate')
+        with pytest.raises(dparser.SyntaxErr):
+            parser.parse('5+x', syntax_error_fn=cb, error_recovery=True)
+    finally:
+        sys.unraisablehook = original_hook
+
+    assert unraised, "expected callback exception to reach sys.unraisablehook"
+    assert isinstance(unraised[0].exc_value, RuntimeError)

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -1,0 +1,83 @@
+"""Tests for parse error behavior: SyntaxErr and syntax_error_fn.
+
+Key findings:
+- Invalid input always raises dparser.SyntaxErr.
+- syntax_error_fn is only invoked when error_recovery=True is passed to parse();
+  without it the C parser fails immediately without calling the callback.
+- Even with error_recovery=True and a syntax_error_fn, SyntaxErr is still raised
+  after the callback returns — the callback is for observing/logging, not suppressing.
+- The DLoc passed to the callback has s/line/col/buf attributes pinpointing the
+  error position in the input buffer.
+"""
+
+import sys
+import pytest
+import dparser
+
+
+def d_S(t):
+    '''S : d '+' d'''
+    return t[0] + t[2]
+
+
+def d_number(t):
+    '''d : "[0-9]+" '''
+    return int(t[0])
+
+
+@pytest.fixture
+def parser(make_parser):
+    return make_parser(sys.modules[__name__])
+
+
+def test_invalid_input_raises_syntax_err(parser):
+    with pytest.raises(dparser.SyntaxErr):
+        parser.parse('not valid')
+
+
+def test_empty_input_raises_syntax_err(parser):
+    with pytest.raises(dparser.SyntaxErr):
+        parser.parse('')
+
+
+def test_incomplete_input_raises_syntax_err(parser):
+    with pytest.raises(dparser.SyntaxErr):
+        parser.parse('5+')
+
+
+def test_syntax_error_fn_not_called_without_error_recovery(parser):
+    called = []
+    try:
+        parser.parse('5+x', syntax_error_fn=lambda loc: called.append(loc))
+    except dparser.SyntaxErr:
+        pass
+    assert not called
+
+
+def test_syntax_error_fn_called_with_error_recovery(parser):
+    called = []
+    try:
+        parser.parse('5+x', syntax_error_fn=lambda loc: called.append(loc),
+                     error_recovery=True)
+    except dparser.SyntaxErr:
+        pass
+    assert len(called) == 1
+
+
+def test_syntax_error_fn_still_raises_with_error_recovery(parser):
+    with pytest.raises(dparser.SyntaxErr):
+        parser.parse('5+x', syntax_error_fn=lambda loc: None,
+                     error_recovery=True)
+
+
+def test_syntax_error_fn_loc_points_to_error_position(parser):
+    locs = []
+    try:
+        parser.parse('5+x', syntax_error_fn=locs.append, error_recovery=True)
+    except dparser.SyntaxErr:
+        pass
+    loc = locs[0]
+    assert loc.buf == b'5+x'
+    assert loc.s == 2       # 'x' is at index 2
+    assert loc.line == 1
+    assert loc.col == 2

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -85,20 +85,18 @@ def test_syntax_error_fn_loc_points_to_error_position(parser):
     assert loc.col == 2
 
 
-def test_syntax_error_fn_exception_does_not_propagate(parser):
+def test_syntax_error_fn_exception_does_not_propagate(parser, monkeypatch):
     # my_syntax_error_fn is declared `noexcept` in dparser.pyx, so any exception
     # raised from the callback is reported via sys.unraisablehook instead of
     # propagating.  SyntaxErr still raises from the native parse failure.
     unraised = []
-    original_hook = sys.unraisablehook
-    sys.unraisablehook = unraised.append
-    try:
-        def cb(loc):
-            raise RuntimeError('should not propagate')
-        with pytest.raises(dparser.SyntaxErr):
-            parser.parse('5+x', syntax_error_fn=cb, error_recovery=True)
-    finally:
-        sys.unraisablehook = original_hook
+    monkeypatch.setattr(sys, 'unraisablehook', unraised.append)
+
+    def cb(loc):
+        raise RuntimeError('should not propagate')
+
+    with pytest.raises(dparser.SyntaxErr):
+        parser.parse('5+x', syntax_error_fn=cb, error_recovery=True)
 
     assert unraised, "expected callback exception to reach sys.unraisablehook"
     assert isinstance(unraised[0].exc_value, RuntimeError)

--- a/python/tests/test_expression_eval.py
+++ b/python/tests/test_expression_eval.py
@@ -1,0 +1,125 @@
+"""Tests for expression evaluation with precedence and ambiguity, converted from test2.py and test3.py."""
+
+import sys
+import types
+import pytest
+
+
+# --- test2 grammar: operator precedence with ambiguity resolution ---
+
+def d_add(t):
+    '''add : add '+' mul
+           | mul'''
+    if len(t) == 1:
+        return t[0]
+    return t[0] + t[2]
+
+
+def d_mul(t):
+    '''mul : mul '*' exp
+           | exp'''
+    if len(t) == 1:
+        return t[0]
+    return t[0] * t[2]
+
+
+def d_exp(t):
+    '''exp : number1
+           | number2
+           | '(' add ')' '''
+    if len(t) == 1:
+        return int(t[0])
+    return t[1]
+
+
+def d_number1(t):
+    '''number1 : number'''
+    return t[0]
+
+
+def d_number2(t):
+    '''number2 : number'''
+    return t[0]
+
+
+def d_number(t):
+    '''number : "[0-9]+"'''
+    return t[0]
+
+
+def ambiguity_func(v):
+    return v[0]
+
+
+def d_whitespace(t, spec):
+    "whitespace : ( ' ' | '\\t' )*"
+    del t, spec
+
+
+@pytest.fixture
+def parser(make_parser):
+    return make_parser(sys.modules[__name__], make_grammar_file=True)
+
+
+def test_precedence_and_parens(parser):
+    result = parser.parse('1  +2* (3+ 4+5)', ambiguity_fn=ambiguity_func)
+    assert result.getStructure() == 25
+
+
+def test_addition(parser):
+    result = parser.parse('1+2', ambiguity_fn=ambiguity_func)
+    assert result.getStructure() == 3
+
+
+def test_multiplication(parser):
+    result = parser.parse('2*3', ambiguity_fn=ambiguity_func)
+    assert result.getStructure() == 6
+
+
+# --- test3 grammar: nodes argument; isolated module to avoid rule name conflicts ---
+
+def _t3_add1(t):
+    "add : add '+' mul"
+    return t[0] + t[2]
+
+
+def _t3_add2(t, nodes):
+    "add : mul"
+    del t
+    return nodes[0].user.t
+
+
+def _t3_mul1(t):
+    "mul : mul '*' exp"
+    return t[0] * t[2]
+
+
+def _t3_mul2(t):
+    "mul : exp"
+    return t[0]
+
+
+def _t3_exp1(t):
+    'exp : "[0-9]+"'
+    return int(t[0])
+
+
+def _t3_exp2(t):
+    "exp : '(' add ')' "
+    return t[1]
+
+
+@pytest.fixture
+def parser_nodes(make_parser):
+    mod = types.ModuleType('_t3_grammar')
+    for attr, fn in [
+        ('d_add1', _t3_add1), ('d_add2', _t3_add2),
+        ('d_mul1', _t3_mul1), ('d_mul2', _t3_mul2),
+        ('d_exp1', _t3_exp1), ('d_exp2', _t3_exp2),
+    ]:
+        setattr(mod, attr, fn)
+    return make_parser(mod)
+
+
+def test_nodes_argument(parser_nodes):
+    assert parser_nodes.parse('3*(3+4)').getStructure() == 21

--- a/python/tests/test_multi_alternative.py
+++ b/python/tests/test_multi_alternative.py
@@ -1,6 +1,5 @@
 import sys
 import pytest
-from dparser import Parser
 
 def d_add(t):
     '''add : add '+' mul
@@ -32,12 +31,8 @@ def d_whitespace(t):
     pass
 
 @pytest.fixture
-def parser(tmp_path):
-    return Parser(
-        modules=sys.modules[__name__],
-        parser_folder=str(tmp_path),
-        make_grammar_file=True
-    )
+def parser(make_parser):
+    return make_parser(sys.modules[__name__], make_grammar_file=True)
 
 def test_multi_alternative_arithmetic(parser):
     # Test cases that exercise both alternatives of add and mul

--- a/python/tests/test_parse_nodes.py
+++ b/python/tests/test_parse_nodes.py
@@ -1,0 +1,61 @@
+"""Tests for nodes/this argument access and parse node attributes, converted from test7.py."""
+
+import sys
+import pytest
+
+
+_captured = {}
+
+
+def d_start(t, nodes, this):
+    'start : noun verb'
+    del t
+    _captured['noun'] = nodes[0]
+    _captured['this'] = this
+
+
+def d_noun(t, this):
+    "noun : 'cat'"
+    del this
+    return t[0]
+
+
+def d_verb(t, this):
+    "verb : 'flies'"
+    del this
+    return t[0]
+
+
+@pytest.fixture
+def parser(make_parser):
+    _captured.clear()
+    return make_parser(sys.modules[__name__])
+
+
+def test_parse_node_buf_slices(parser):
+    parser.parse('cat flies')
+
+    noun = _captured['noun']
+    this = _captured['this']
+    buf = noun.buf
+
+    assert buf[noun.start_loc.s:noun.end] == b'cat'
+    assert buf[noun.end:noun.end + 1] == b' '
+    assert buf[noun.end_skip:noun.end_skip + 5] == b'flies'
+    assert buf[this.start_loc.s:this.end] == b'cat flies'
+
+
+def test_parse_node_location(parser):
+    parser.parse('cat flies')
+
+    noun = _captured['noun']
+    assert isinstance(noun.start_loc.line, int)
+    assert isinstance(noun.start_loc.col, int)
+
+
+def test_this_node_spans_full_input(parser):
+    parser.parse('cat flies')
+
+    this = _captured['this']
+    buf = this.buf
+    assert buf[this.start_loc.s:this.end] == b'cat flies'

--- a/python/tests/test_parse_nodes.py
+++ b/python/tests/test_parse_nodes.py
@@ -1,42 +1,42 @@
 """Tests for nodes/this argument access and parse node attributes, converted from test7.py."""
 
-import sys
+import types
 import pytest
 
 
-_captured = {}
-
-
-def d_start(t, nodes, this):
-    'start : noun verb'
-    del t
-    _captured['noun'] = nodes[0]
-    _captured['this'] = this
-
-
-def d_noun(t, this):
-    "noun : 'cat'"
-    del this
-    return t[0]
-
-
-def d_verb(t, this):
-    "verb : 'flies'"
-    del this
-    return t[0]
-
-
 @pytest.fixture
-def parser(make_parser):
-    _captured.clear()
-    return make_parser(sys.modules[__name__])
+def parser_with_captures(make_parser):
+    captured = {}
+
+    def d_start(t, nodes, this):
+        'start : noun verb'
+        del t
+        captured['noun'] = nodes[0]
+        captured['this'] = this
+
+    def d_noun(t, this):
+        "noun : 'cat'"
+        del this
+        return t[0]
+
+    def d_verb(t, this):
+        "verb : 'flies'"
+        del this
+        return t[0]
+
+    mod = types.ModuleType('_parse_nodes_grammar')
+    mod.d_start = d_start
+    mod.d_noun = d_noun
+    mod.d_verb = d_verb
+    return make_parser(mod), captured
 
 
-def test_parse_node_buf_slices(parser):
+def test_parse_node_buf_slices(parser_with_captures):
+    parser, captured = parser_with_captures
     parser.parse('cat flies')
 
-    noun = _captured['noun']
-    this = _captured['this']
+    noun = captured['noun']
+    this = captured['this']
     buf = noun.buf
 
     assert buf[noun.start_loc.s:noun.end] == b'cat'
@@ -45,17 +45,19 @@ def test_parse_node_buf_slices(parser):
     assert buf[this.start_loc.s:this.end] == b'cat flies'
 
 
-def test_parse_node_location(parser):
+def test_parse_node_location(parser_with_captures):
+    parser, captured = parser_with_captures
     parser.parse('cat flies')
 
-    noun = _captured['noun']
+    noun = captured['noun']
     assert isinstance(noun.start_loc.line, int)
     assert isinstance(noun.start_loc.col, int)
 
 
-def test_this_node_spans_full_input(parser):
+def test_this_node_spans_full_input(parser_with_captures):
+    parser, captured = parser_with_captures
     parser.parse('cat flies')
 
-    this = _captured['this']
+    this = captured['this']
     buf = this.buf
     assert buf[this.start_loc.s:this.end] == b'cat flies'

--- a/python/tests/test_speculative_gate.py
+++ b/python/tests/test_speculative_gate.py
@@ -12,35 +12,35 @@ test uses the `spec_only` argument (which both receives the speculative flag
 runs in.
 """
 
-import sys
+import types
 import pytest
 
 
-_calls = []
-
-
-def d_S(t, spec_only):
-    """S : d '+' d"""
-    _calls.append(('S', spec_only))
-    return t[0] + t[2]
-
-
-def d_number(t, spec_only):
-    '''d : "[0-9]+" '''
-    _calls.append(('d', spec_only))
-    return int(t[0])
-
-
 @pytest.fixture
-def parser(make_parser):
-    _calls.clear()
-    return make_parser(sys.modules[__name__])
+def parser_with_calls(make_parser):
+    calls = []
+
+    def d_S(t, spec_only):
+        """S : d '+' d"""
+        calls.append(('S', spec_only))
+        return t[0] + t[2]
+
+    def d_number(t, spec_only):
+        '''d : "[0-9]+" '''
+        calls.append(('d', spec_only))
+        return int(t[0])
+
+    mod = types.ModuleType('_spec_gate_grammar')
+    mod.d_S = d_S
+    mod.d_number = d_number
+    return make_parser(mod), calls
 
 
-def test_default_actions_run_in_final_pass_only(parser):
+def test_default_actions_run_in_final_pass_only(parser_with_calls):
+    parser, calls = parser_with_calls
     assert parser.parse('87+5').getStructure() == 92
-    assert _calls, "expected actions to fire"
-    assert all(flag == 0 for _, flag in _calls), (
+    assert calls, "expected actions to fire"
+    assert all(flag == 0 for _, flag in calls), (
         f"expected every action to fire in the final pass (spec=0), "
-        f"got: {_calls}"
+        f"got: {calls}"
     )

--- a/python/tests/test_speculative_gate.py
+++ b/python/tests/test_speculative_gate.py
@@ -14,7 +14,6 @@ runs in.
 
 import sys
 import pytest
-from dparser import Parser
 
 
 _calls = []
@@ -33,12 +32,9 @@ def d_number(t, spec_only):
 
 
 @pytest.fixture
-def parser(tmp_path):
+def parser(make_parser):
     _calls.clear()
-    return Parser(
-        modules=sys.modules[__name__],
-        parser_folder=str(tmp_path),
-    )
+    return make_parser(sys.modules[__name__])
 
 
 def test_default_actions_run_in_final_pass_only(parser):

--- a/python/tests/test_speculative_parsing.py
+++ b/python/tests/test_speculative_parsing.py
@@ -1,0 +1,89 @@
+"""Tests for speculative parsing with Reject and spec/spec_only arguments, converted from test4.py and test5.py."""
+
+import types
+import pytest
+import dparser
+
+
+# --- test4 grammar: ambiguity resolved by rejecting x2 in speculative pass ---
+
+def _t4_S(t):
+    "S: a | b"
+    del t
+    return 'S'
+
+
+def _t4_a(t):
+    "a : x1 x1 'y'"
+    del t
+
+
+def _t4_b(t):
+    "b : x2 x2 'y'"
+    del t
+
+
+def _t4_x1(t, spec):
+    "x1 : 'x'"
+    del t, spec
+
+
+def _t4_x2(t, spec):
+    "x2 : 'x'"
+    del t
+    if spec:
+        return dparser.Reject
+
+
+def _syntax_error(t):
+    del t
+    raise AssertionError("unexpected syntax error")
+
+
+@pytest.fixture
+def parser_reject(make_parser):
+    mod = types.ModuleType('_t4_grammar')
+    for attr, fn in [
+        ('d_S', _t4_S), ('d_a', _t4_a), ('d_b', _t4_b),
+        ('d_x1', _t4_x1), ('d_x2', _t4_x2),
+    ]:
+        setattr(mod, attr, fn)
+    return make_parser(mod)
+
+
+def test_spec_reject_resolves_ambiguity(parser_reject):
+    result = parser_reject.parse('xxy', syntax_error_fn=_syntax_error)
+    assert result.getStructure() == 'S'
+
+
+# --- test5 grammar: spec_only action wins over spec-rejecting alternative ---
+
+def _t5_h(t):
+    'h : h1 | h2'
+    return t[0]
+
+
+def _t5_h1(t, spec_only):
+    "h1 : 'a'"
+    del t, spec_only
+    return 1
+
+
+def _t5_h2(t, spec):
+    "h2 : 'a'"
+    del t
+    if spec:
+        return dparser.Reject
+    return 2
+
+
+@pytest.fixture
+def parser_spec_only(make_parser):
+    mod = types.ModuleType('_t5_grammar')
+    for attr, fn in [('d_h', _t5_h), ('d_h1', _t5_h1), ('d_h2', _t5_h2)]:
+        setattr(mod, attr, fn)
+    return make_parser(mod)
+
+
+def test_spec_only_action_wins(parser_spec_only):
+    assert parser_spec_only.parse('a').getStructure() == 1

--- a/python/tests/test_speculative_parsing.py
+++ b/python/tests/test_speculative_parsing.py
@@ -35,11 +35,6 @@ def _t4_x2(t, spec):
         return dparser.Reject
 
 
-def _syntax_error(t):
-    del t
-    raise AssertionError("unexpected syntax error")
-
-
 @pytest.fixture
 def parser_reject(make_parser):
     mod = types.ModuleType('_t4_grammar')
@@ -52,7 +47,9 @@ def parser_reject(make_parser):
 
 
 def test_spec_reject_resolves_ambiguity(parser_reject):
-    result = parser_reject.parse('xxy', syntax_error_fn=_syntax_error)
+    # If x2's speculative Reject doesn't resolve the a/b ambiguity, parse()
+    # raises SyntaxErr and the test fails naturally.
+    result = parser_reject.parse('xxy')
     assert result.getStructure() == 'S'
 
 

--- a/python/tests/test_string_replace.py
+++ b/python/tests/test_string_replace.py
@@ -1,0 +1,46 @@
+"""Tests for string replacement via the s argument, converted from test6.py."""
+
+import sys
+import pytest
+
+
+def stringify(s):
+    if not isinstance(s, str):
+        return ''.join(map(stringify, s))
+    return s
+
+
+def d_add1(t, s):
+    "add : add '%' exp"
+    s[1] = '+ '
+    del t
+
+
+def d_add2(t, s):
+    "add : exp"
+    del t, s
+
+
+def d_exp(t):
+    'exp : "[0-9]+" '
+    del t
+
+
+@pytest.fixture
+def parser(make_parser):
+    return make_parser(sys.modules[__name__])
+
+
+def test_percent_replaced_with_plus(parser):
+    result = parser.parse('1 % 2 % 3')
+    assert stringify(result.getStringLeft()) == '1 + 2 + 3'
+
+
+def test_single_replacement(parser):
+    result = parser.parse('1 % 2')
+    assert stringify(result.getStringLeft()) == '1 + 2'
+
+
+def test_no_replacement(parser):
+    result = parser.parse('42')
+    assert stringify(result.getStringLeft()) == '42'

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -3,6 +3,154 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "dparser"
 version = "1.31"
 source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "dparser"
+version = "1.31"
+source = { editable = "." }


### PR DESCRIPTION
## Summary

- Convert the legacy `test.py`–`test7.py` scripts to a pytest suite (30 tests). A `make_parser` factory fixture in `conftest.py` handles Parser construction and isolates each test's grammar cache via `tmp_path`.
- Add pin-down tests for non-obvious binding behavior uncovered during the conversion: `partial_parses` / `buf_offset` semantics, `ambiguity_fn`'s node-identity contract with unpopulated user values at call time, `syntax_error_fn`'s `error_recovery=True` gating, and the `noexcept` exception swallowing in both Cython callback wrappers.
- Write the findings up in `tests/dparser_binding_behavior.md`. Each section is paired with a pin-down test in the suite so the doc and the tests corroborate each other.
- Add `pytest>=9.0.3` to the dev dependency group in `pyproject.toml`.

## Notable findings captured

- `partial_parses=1` silently drops trailing content — no skip-fn required.
- `buf_offset=N` skips arbitrary bytes, not just whitespace.
- `ambiguity_fn` receives `DParseNode` objects with `user.t` unpopulated; disambiguation must be by node identity, not return value.
- Ambiguous grammars **hang indefinitely** without an `ambiguity_fn`.
- `dparser.SyntaxErr` is independent of `ParsingException` and fires for empty/incomplete input.
- `syntax_error_fn` is only called when `error_recovery=True`; `SyntaxErr` still raises after the callback.
- Exceptions from `syntax_error_fn` go through `sys.unraisablehook` (Cython `noexcept`); exceptions from `ambiguity_fn` go through an explicit `try/except Exception → v[0]` fallback. Neither propagates to the caller of `parse()`.

## Notes

- Legacy `test.py`, `test2.py`…`test7.py` are left in place. pytest doesn't collect them (filename-pattern mismatch), but `test3.py` calls `os._exit(0)` at import time, so they should eventually be deleted by the primary maintainer.
- Generated parser artifacts (`d_parser_mach_gen.g.*`, `dparser.c`, built `.so`) are untracked; a `.gitignore` entry in a follow-up would make `git status` clean.

## Test plan

- [ ] `cd python && uv run pytest tests/` — 30 passed
- [ ] `cd python && uv run pytest tests/ -p no:cacheprovider` — still 30 passed (no reliance on pytest cache)
- [ ] `tests/dparser_binding_behavior.md` renders cleanly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)